### PR TITLE
Fix export data message typo

### DIFF
--- a/core/management/commands/export_data.py
+++ b/core/management/commands/export_data.py
@@ -24,7 +24,7 @@ class Command(BaseCommand):
         )
         df_pred= pd.DataFrame.from_records(qs)
         df_pred.to_parquet('data/predicciones.parquet', index=False)
-        self.stdout.write(self.style.SUCCESS('✔ predicciones.parquet creado"'))
+        self.stdout.write(self.style.SUCCESS('✔ predicciones.parquet creado'))
 
         # 3) Exportar bonus (opcional)
         qs = PrediccionBonus.objects.all().values(


### PR DESCRIPTION
## Summary
- remove stray quote in the export_data command output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867a4442c3c8329a32e3800b0530ef9