### PR TITLE
Fix duplicate calcular_puntos import

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -4,7 +4,7 @@ from django.contrib import messages
 from django.contrib.auth.models import User
 from django.contrib.admin.views.decorators import staff_member_required
 from .models import Fase, Partido, Prediccion, PerfilUsuario
-from .utils import actualizar_fases_automaticamente, calcular_puntos
+from .utils import actualizar_fases_automaticamente
 from .forms import PrediccionBonusForm
 from .models import PrediccionBonus
 from .utils import calcular_puntos, puntos_por_bonus


### PR DESCRIPTION
## Summary
- keep only one import of `calcular_puntos`

## Testing
- `python manage.py test`
- `python manage.py check`
- `python -m py_compile core/views.py`

------
https://chatgpt.com/codex/tasks/task_e_6867a441eb648329974c2ea75fa6423d