### PR TITLE
Fix bonus prediction exception handling

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -55,5 +55,5 @@ def puntos_por_bonus(usuario):
         if campeon_real is None:
             return 0
         return 5 if bonus.campeon.lower() == campeon_real.lower() else 0
-    except:
+    except PrediccionBonus.DoesNotExist:
         return 0


### PR DESCRIPTION
## Summary
- handle PrediccionBonus.DoesNotExist specifically in `puntos_por_bonus`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867a442fd8883298df9de8f5607b519