### PR TITLE
Update predictions form logic

### DIFF
--- a/core/templates/core/predicciones.html
+++ b/core/templates/core/predicciones.html
@@ -20,7 +20,7 @@
         <td>{{ partido.equipo_local }} vs {{ partido.equipo_visitante }}</td>
         <td>{{ partido.fecha }}</td>
         <td>
-          {% if partido in predicciones.values_list 'partido' %}
+          {% if partido.id in predicciones_ids %}
             Ya enviado
           {% else %}
             <input type="number" name="goles_local_{{ partido.id }}" min="0" required> -

--- a/core/utils.py
+++ b/core/utils.py
@@ -51,19 +51,14 @@ def obtener_campeon_real():
 def puntos_por_bonus(usuario):
     try:
         bonus = usuario.prediccionbonus
-
-        campeon_real = obtener_campeon_real()
-        if campeon_real is None:
-            return 0
-        return 5 if bonus.campeon.lower() == campeon_real.lower() else 0
-    except:
-        return 0
-
     except PrediccionBonus.DoesNotExist:
         return 0
 
     campeon_real = obtener_campeon_real()
     if campeon_real is None:
         return 0
-    return 5 if bonus.campeon.lower() == campeon_real.lower() else 0
+    try:
+        return 5 if bonus.campeon.lower() == campeon_real.lower() else 0
+    except Exception:
+        return 0
 

--- a/core/views.py
+++ b/core/views.py
@@ -28,6 +28,7 @@ def predicciones_disponibles(request):
     fases = Fase.objects.filter(desbloqueada=True).order_by('orden')
     partidos = Partido.objects.filter(fase__in=fases).order_by('fecha')
     predicciones_hechas = Prediccion.objects.filter(usuario=request.user)
+    predicciones_ids = set(predicciones_hechas.values_list('partido_id', flat=True))
 
     if request.method == 'POST':
         for partido in partidos:
@@ -52,7 +53,8 @@ def predicciones_disponibles(request):
 
     return render(request, 'core/predicciones.html', {
         'partidos': partidos,
-        'predicciones': predicciones_hechas
+        'predicciones': predicciones_hechas,
+        'predicciones_ids': predicciones_ids
     })
 
 


### PR DESCRIPTION
## Summary
- send predicted match ids in context
- display proper input state in predictions form
- fix `puntos_por_bonus` exception logic

## Testing
- `python manage.py migrate --noinput`
- `python manage.py shell -c "import django; django.setup(); from core.models import Prediccion; print(set(Prediccion.objects.all().values_list('partido_id', flat=True)))"`
- `python manage.py shell <<'EOF'
from django.test.client import RequestFactory
from django.contrib.auth.models import User
from core.models import PerfilUsuario, Fase, Partido
import core.views as views
user = User.objects.create_user(username='tester6', password='pass')
perfil = user.perfilusuario
perfil.validado = True
perfil.save()
fase = Fase.objects.create(nombre='Fase1', orden=1, desbloqueada=True)
Partido.objects.create(fase=fase, equipo_local='A', equipo_visitante='B', fecha='2023-01-01T00:00Z')
factory = RequestFactory()
request = factory.get('/predicciones/')
request.user = user
captured = {}
def fake_render(request, template, context=None):
    captured['template'] = template
    captured['context'] = context
    from django.http import HttpResponse
    return HttpResponse('ok')
orig_render = views.render
views.render = fake_render
views.predicciones_disponibles.__wrapped__(request)
views.render = orig_render
print(captured['template'])
print('predicciones_ids' in captured['context'])
print(captured['context']['predicciones_ids'])
EOF

------
https://chatgpt.com/codex/tasks/task_e_6867ad2a1b1083298cb1df0982e5cfbd